### PR TITLE
Support for external interfaces to other master tools

### DIFF
--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -29,4 +29,4 @@ set_target_properties(OMSimulatorLib PROPERTIES OUTPUT_NAME OMSimulatorLib)
 set_target_properties(OMSimulatorLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 install(TARGETS OMSimulatorLib DESTINATION lib)
 
-install(FILES OMSimulator.h DESTINATION include)
+install(FILES OMSimulator.h Types.h DESTINATION include)

--- a/src/OMSimulatorLib/CompositeModel.h
+++ b/src/OMSimulatorLib/CompositeModel.h
@@ -75,6 +75,11 @@ public:
 
   void setVariableFilter(const char* instanceFilter, const char* variableFilter);
 
+  int getNumberOfInterfaces();
+  oms_causality_t getInterfaceCausality(int idx);
+  const char* getInterfaceName(int idx);
+  const char* getInterfaceVariable(int idx);
+
 private:
   void updateInputs(DirectedGraph& graph);
   void emit();
@@ -90,6 +95,9 @@ private:
   double tcur;
   oms_modelState_t modelState;
   double communicationInterval;
+
+  std::vector<std::string>  interfaceNames;
+  std::vector<std::string>  interfaceVariables;
 };
 
 #endif

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -374,3 +374,49 @@ void oms_setVariableFilter(void* model, const char* instanceFilter, const char* 
   CompositeModel* pModel = (CompositeModel*)model;
   pModel->setVariableFilter(instanceFilter, variableFilter);
 }
+
+int oms_getNumberOfInterfaces(void *model)
+{
+  if (!model)
+  {
+    return -1;
+  }
+
+  CompositeModel* pModel = (CompositeModel*)model;
+  return pModel->getNumberOfInterfaces();
+}
+
+oms_causality_t oms_getInterfaceCausality(void *model, int idx)
+{
+  if (!model)
+  {
+    return oms_causality_undefined;
+  }
+
+  CompositeModel* pModel = (CompositeModel*)model;
+  return pModel->getInterfaceCausality(idx);
+}
+
+const char *oms_getInterfaceName(void *model, int idx)
+{
+  if (!model)
+  {
+    logError("oms_getInterfaceName: invalid pointer");
+    return NULL;
+  }
+
+  CompositeModel* pModel = (CompositeModel*)model;
+  return pModel->getInterfaceName(idx);
+}
+
+const char *oms_getInterfaceVariable(void *model, int idx)
+{
+  if (!model)
+  {
+    logError("oms_getInterfaceName: invalid pointer");
+    return NULL;
+  }
+
+  CompositeModel* pModel = (CompositeModel*)model;
+  return pModel->getInterfaceVariable(idx);
+}

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -203,6 +203,41 @@ int oms_compareSimulationResults(const char* filenameA, const char* filenameB, c
  */
 void oms_setVariableFilter(void* model, const char* instanceFilter, const char* variableFilter);
 
+/**
+ * \brief Returns the number of external interfaces
+ *
+ * @param model   [in] Model as opaque pointer.
+ * @return        Number of interfaces
+ */
+int oms_getNumberOfInterfaces(void* model);
+
+/**
+ * \brief Returns the causality for specified external interface
+ *
+ * @param model   [in] Model as opaque pointer.
+ * @param idx     [in] Interface index
+ * @return        Interface causality
+ */
+oms_causality_t oms_getInterfaceCausality(void* model, int idx);
+
+/**
+ * \brief Returns the name for specified external interface
+ *
+ * @param model   [in] Model as opaque pointer.
+ * @param idx     [in] Interface index
+ * @return        Interface name
+ */
+const char* oms_getInterfaceName(void* model, int idx);
+
+/**
+ * \brief Returns the local variable mapped to specified external interface
+ *
+ * @param model   [in] Model as opaque pointer.
+ * @param idx     [in] Interface index
+ * @return        Mapped variable
+ */
+const char* oms_getInterfaceVariable(void* model, int idx);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -53,6 +53,13 @@ typedef enum {
   oms_modelState_simulation
 } oms_modelState_t;
 
+typedef enum {
+  oms_causality_input,
+  oms_causality_output,
+  oms_causality_parameter,
+  oms_causality_undefined,
+} oms_causality_t;
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Interfaces are specified in XML file. Interface names, causalities and the mapped internal variables can be accessed through the C API.

The other master tool (e.g. OMTLMSimulator) then call oms_setReal() and oms_getReal() using the provided variable strings.

