### PR TITLE
Implement a timeout mechanism

### DIFF
--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -2,6 +2,8 @@ project(OMSimulator)
 
 set(CMAKE_INSTALL_RPATH "$ORIGIN")
 
+find_package (Threads)
+
 include_directories(../OMSimulatorLib)
 include_directories(../OMSimulatorLua)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -14,7 +16,7 @@ link_directories(${CVODELibrary_LIBRARYDIR})
 
 add_executable(OMSimulator main.cpp Options.cpp)
 
-target_link_libraries(OMSimulator lua OMSimulatorLib fmilib_shared sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(OMSimulator lua OMSimulatorLib fmilib_shared sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 # set_property(TARGET OMSimulator PROPERTY CXX_STANDARD 11)
 

--- a/src/OMSimulator/Options.cpp
+++ b/src/OMSimulator/Options.cpp
@@ -49,6 +49,7 @@ ProgramOptions::ProgramOptions()
   useStartTime = false;
   stopTime = 1.0;
   useStopTime = false;
+  timeout = 0;
   tolerance = 1e-6;
   useTolerance = false;
   communicationInterval = 1e-1;
@@ -70,6 +71,7 @@ bool ProgramOptions::load_flags(int argc, char** argv)
   ("resultFile,r", boost::program_options::value<std::string>(&resultFile), "Specifies the name of the output result file")
   ("startTime,s", boost::program_options::value<double>(&startTime), "Specifies the start time.")
   ("stopTime,t", boost::program_options::value<double>(&stopTime), "Specifies the stop time.")
+  ("timeout", boost::program_options::value<double>(&timeout), "Specifies the maximum allowed time in seconds for running a simulation (0 disables).")
   ("tempDir", boost::program_options::value<std::string>(&tempDir), "Specifies the temp directory.")
   ("tolerance", boost::program_options::value<double>(&tolerance), "Specifies the relative tolerance.")
   ("version,v", "Displays version information.")

--- a/src/OMSimulator/Options.h
+++ b/src/OMSimulator/Options.h
@@ -63,6 +63,7 @@ public:
   std::string tempDir;
   std::string workingDir;
   std::string logfile;
+  double timeout;
 };
 
 #endif

--- a/src/OMSimulator/main.cpp
+++ b/src/OMSimulator/main.cpp
@@ -66,13 +66,14 @@ static int do_simulation(void* pModel, std::chrono::duration<double> timeout)
   oms_initialize(pModel);
   phase = "Timeout occurred during simulation";
   oms_simulate(pModel);
-  phase = "Timeout occurred during termination";
-  oms_terminate(pModel);
 
   done=1;
 
   cv.notify_one();
   t.join();
+
+  oms_terminate(pModel);
+  oms_unload(pModel);
 
   return 0;
 }

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -34,6 +34,7 @@
 
 #include <string>
 #include <fstream>
+#include <mutex>
 
 //#define OMS_DEBUG_LOGGING
 
@@ -54,7 +55,7 @@ public:
   void Debug(const std::string& msg);
   void Warning(const std::string& msg);
   void Error(const std::string& msg);
-  void Fatal(const std::string& msg);
+  [[noreturn]] void Fatal(const std::string& msg);
   void Trace(const std::string& function, const std::string& file, const long line);
 
   void setLogFile(const std::string& filename);
@@ -70,10 +71,12 @@ private:
   Log(Log const& copy);            // Not Implemented
   Log& operator=(Log const& copy); // Not Implemented
 
+  bool processTerminating;
   bool initialized;
   bool useStdStream;
   std::string filename;
   std::ofstream logFile;
+  std::mutex m;
   unsigned int numWarnings;
   unsigned int numErrors;
 };


### PR DESCRIPTION
This causes the simulation to simply stop. It could be done in a nicer
way where before and/or after each FMI/solver call a check if the
process has been interrupted (or perhaps is close to its timeout) and
should exit cleanly. This is a rough first attempt to just kills the
process (although destructors, etc are executed).